### PR TITLE
Support fuzzing of Android unit tests

### DIFF
--- a/.github/workflows/pipeline_pr.yml
+++ b/.github/workflows/pipeline_pr.yml
@@ -16,11 +16,14 @@ jobs:
     steps:
       - name: git clone
         uses: actions/checkout@v3.4.0
-      - name: Set up JDK 
-        uses: actions/setup-java@v3.10.0
+      - name: Set up JDKs
+        uses: actions/setup-java@v3.11.0
         with:
           distribution: temurin
-          java-version: 8 
+          java-version: |
+            8
+            11
+            17
       - name: Set up Gradle
         uses: gradle/gradle-build-action@v2.4.2
       - run: "./gradlew :check --continue"

--- a/.github/workflows/pipeline_push.yml
+++ b/.github/workflows/pipeline_push.yml
@@ -14,11 +14,13 @@ jobs:
     steps:
       - name: git clone
         uses: actions/checkout@v3.4.0
-      - name: Set up JDK
-        uses: actions/setup-java@v3.10.0
+      - name: Set up JDKs
+        uses: actions/setup-java@v3.11.0
         with:
           distribution: temurin
-          java-version: 8 
+          java-version: |
+            8
+            11
       - name: Set up Gradle
         uses: gradle/gradle-build-action@v2.4.2
       - run: "./gradlew :test"

--- a/.github/workflows/pipeline_release.yml
+++ b/.github/workflows/pipeline_release.yml
@@ -24,11 +24,11 @@ jobs:
     steps:
       - name: git clone
         uses: actions/checkout@v3.4.0
-      - name: Set up JDK 11
-        uses: actions/setup-java@v3.10.0
+      - name: Set up JDKs
+        uses: actions/setup-java@v3.11.0
         with:
           distribution: temurin
-          java-version: 11
+          java-version: 8
       - name: Set up Gradle
         uses: gradle/gradle-build-action@v2.4.2
       - run: "./gradlew :publishPlugin -PpluginVersion=${{ needs.version.outputs.version }}"

--- a/README.md
+++ b/README.md
@@ -64,11 +64,10 @@ cifuzz {
 
 ### Android projects
 
-In Android projects, you can configure the _androidVariant_ (default is `release`) and if the fuzz tests are Android device tests (and not a unit tests, which is the default).
+In Android projects, you can configure the _androidVariant_ for which to run the fuzz tests (default is `release`).
 
 ```kotlin
 cifuzz {
     androidVariant.set("fullDebug") // Set to variant for flavor=full and buildType=debug 
-    androidTest.set(true) // The fuzz tests are in 'androidTest' and not in 'test' 
 }
 ```

--- a/README.md
+++ b/README.md
@@ -20,7 +20,10 @@ plugins {
 }
 ```
 
-The minimum supported Gradle version is **Gradle 6.1**.
+## Compatibility
+
+- For JVM (Java, Kotlin, ...) projects, the minimum supported Gradle version is **Gradle 6.1**
+- For Android projects, 7.5 (Android Gradle Plugin 7.4) or 8.0 (Android Gradle Plugin 8.0) are the minimum supported Gradle version
 
 ## Writing fuzz tests with Jazzer and JUnit 5
 
@@ -32,6 +35,8 @@ You can then use the [cifuzz](https://github.com/CodeIntelligenceTesting/cifuzz)
 
 By default, the plugin expects all fuzz tests to be in the default test sources set, which is usually located in `src/test`.
 If the tests are in a separate test source set – or test suite – you have to configure that.
+
+### Standard JVM (Java, Kotlin, ...) projects
 
 If you use [test suites](https://docs.gradle.org/current/userguide/jvm_test_suite_plugin.html) (available since Gradle 7.4) you can do the configuration as follows:
 ```kotlin
@@ -57,3 +62,13 @@ cifuzz {
 }
 ```
 
+### Android projects
+
+In Android projects, you can configure the _androidVariant_ (default is `release`) and if the fuzz tests are Android device tests (and not a unit tests, which is the default).
+
+```kotlin
+cifuzz {
+    androidVariant.set("fullDebug") // Set to variant for flavor=full and buildType=debug 
+    androidTest.set(true) // The fuzz tests are in 'androidTest' and not in 'test' 
+}
+```

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -5,6 +5,8 @@ plugins {
 
 // Versions to test in addition to the version used to build the plugin (gradle/wrapper/gradle-wrapper.properties)
 val testedGradleVersions = listOf("6.1.1", "7.0.2", "7.3.3", "7.4.2", "7.5.1", "7.6.1")
+// Versions for which the Android support, which is not available for older Gradle versions, is tested
+val testedGradleVersionsAndroid = listOf("7.5.1", "7.6.1")
 
 group = "com.code-intelligence"
 version = providers.gradleProperty("pluginVersion").getOrElse("dev")
@@ -52,8 +54,13 @@ testedGradleVersions.forEach { gradleVersionUnderTest ->
         description = "Runs tests against Gradle $gradleVersionUnderTest"
         testClassesDirs = sourceSets.test.get().output.classesDirs
         classpath = sourceSets.test.get().runtimeClasspath
-        useJUnitPlatform { excludeTags = setOf("android") }
         systemProperty("gradleVersionUnderTest", gradleVersionUnderTest)
+        if (testedGradleVersionsAndroid.contains(gradleVersionUnderTest)) {
+            javaLauncher.set(javaToolchains.launcherFor { languageVersion.set(JavaLanguageVersion.of(11)) })
+            useJUnitPlatform()
+        } else {
+            useJUnitPlatform { excludeTags = setOf("android") }
+        }
     }
     tasks.check {
         dependsOn(testGradle)

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -46,6 +46,9 @@ testedGradleVersions.forEach { gradleVersionUnderTest ->
     }
 }
 
+publishing.repositories.maven(layout.buildDirectory.dir("pluginUnderTestRepo"))
+
 tasks.withType<Test>().configureEach {
+    dependsOn(tasks.publish)
     maxParallelForks = 4
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -7,6 +7,8 @@ plugins {
 val testedGradleVersions = listOf("6.1.1", "7.0.2", "7.3.3", "7.4.2", "7.5.1", "7.6.1")
 // Versions for which the Android support, which is not available for older Gradle versions, is tested
 val testedGradleVersionsAndroid = listOf("7.5.1", "7.6.1")
+// Versions of the Android plugin to test in addition to the one used in examples/multi-project-android-app
+val testedAndroidPluginVersions = listOf("8.0.0")
 
 group = "com.code-intelligence"
 version = providers.gradleProperty("pluginVersion").getOrElse("dev")
@@ -48,6 +50,7 @@ testing.suites.named<JvmTestSuite>("test") {
     }
 }
 
+// Test additional Gradle versions
 testedGradleVersions.forEach { gradleVersionUnderTest ->
     val testGradle = tasks.register<Test>("testGradle$gradleVersionUnderTest") {
         group = "verification"
@@ -61,6 +64,22 @@ testedGradleVersions.forEach { gradleVersionUnderTest ->
         } else {
             useJUnitPlatform { excludeTags = setOf("android") }
         }
+    }
+    tasks.check {
+        dependsOn(testGradle)
+    }
+}
+
+// Test additional Android Gradle Plugin versions (with the current Gradle version)
+testedAndroidPluginVersions.forEach { androidPluginVersions ->
+    val testGradle = tasks.register<Test>("testAndroid$androidPluginVersions") {
+        group = "verification"
+        description = "Runs tests against Android Gradle Plugin $androidPluginVersions"
+        testClassesDirs = sourceSets.test.get().output.classesDirs
+        classpath = sourceSets.test.get().runtimeClasspath
+        systemProperty("androidPluginVersionUnderTest", androidPluginVersions)
+        useJUnitPlatform { includeTags = setOf("android") }
+        javaLauncher.set(javaToolchains.launcherFor { languageVersion.set(JavaLanguageVersion.of(17)) })
     }
     tasks.check {
         dependsOn(testGradle)

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -25,10 +25,24 @@ gradlePlugin {
     }
 }
 
+configurations.compileClasspath {
+    // Allow Java 11 dependencies on compile classpath
+    attributes.attribute(TargetJvmVersion.TARGET_JVM_VERSION_ATTRIBUTE, 11)
+}
+dependencies {
+    compileOnly("com.android.tools.build:gradle:7.4.2")
+}
+
 testing.suites.named<JvmTestSuite>("test") {
     useJUnitJupiter()
     dependencies {
         implementation("org.hamcrest:hamcrest:2.2")
+    }
+    targets.all {
+        testTask {
+            // Android testing requires Java 11
+            javaLauncher.set(javaToolchains.launcherFor { languageVersion.set(JavaLanguageVersion.of(11)) })
+        }
     }
 }
 
@@ -38,7 +52,7 @@ testedGradleVersions.forEach { gradleVersionUnderTest ->
         description = "Runs tests against Gradle $gradleVersionUnderTest"
         testClassesDirs = sourceSets.test.get().output.classesDirs
         classpath = sourceSets.test.get().runtimeClasspath
-        useJUnitPlatform()
+        useJUnitPlatform { excludeTags = setOf("android") }
         systemProperty("gradleVersionUnderTest", gradleVersionUnderTest)
     }
     tasks.check {

--- a/examples/multi-project-android-app/.gitignore
+++ b/examples/multi-project-android-app/.gitignore
@@ -1,0 +1,6 @@
+.gradle
+.idea
+build
+/gradle/wrapper
+/gradlew
+/gradlew.bat

--- a/examples/multi-project-android-app/app/build.gradle.kts
+++ b/examples/multi-project-android-app/app/build.gradle.kts
@@ -12,7 +12,7 @@ android {
 
     defaultConfig {
         applicationId = "org.example"
-        minSdk = 24
+        minSdk = 26
         targetSdk = 33
         versionCode = 1
         versionName = "1.0"

--- a/examples/multi-project-android-app/app/build.gradle.kts
+++ b/examples/multi-project-android-app/app/build.gradle.kts
@@ -1,0 +1,47 @@
+import com.android.build.api.variant.AndroidComponentsExtension
+import com.code_intelligence.cifuzz.tasks.ClasspathPrinter
+
+plugins {
+    id("com.android.application") version "7.4.2"
+    id("org.jetbrains.kotlin.android") version "1.8.20"
+    id("com.code-intelligence.cifuzz") version "dev"
+}
+
+// cifuzz.androidVariant.set("release")
+
+repositories {
+    mavenCentral()
+    google()
+}
+
+android {
+    namespace = "org.example"
+    compileSdk = 33
+
+    defaultConfig {
+        applicationId = "org.example"
+        minSdk = 24
+        targetSdk = 33
+        versionCode = 1
+        versionName = "1.0"
+
+        testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
+    }
+
+    compileOptions {
+        sourceCompatibility = JavaVersion.VERSION_1_8
+        targetCompatibility = JavaVersion.VERSION_1_8
+    }
+    kotlinOptions {
+        jvmTarget = "1.8"
+    }
+}
+
+tasks.withType<Test>().configureEach {
+    useJUnitPlatform()
+}
+
+dependencies {
+    testImplementation("org.junit.jupiter:junit-jupiter:5.9.2")
+    testImplementation("com.code-intelligence:jazzer-junit:0.15.0")
+}

--- a/examples/multi-project-android-app/app/build.gradle.kts
+++ b/examples/multi-project-android-app/app/build.gradle.kts
@@ -7,7 +7,7 @@ plugins {
     id("com.code-intelligence.cifuzz") version "dev"
 }
 
-// cifuzz.androidVariant.set("release")
+// cifuzz.androidVariant.set("debug")
 
 repositories {
     mavenCentral()
@@ -35,13 +35,4 @@ android {
     kotlinOptions {
         jvmTarget = "1.8"
     }
-}
-
-tasks.withType<Test>().configureEach {
-    useJUnitPlatform()
-}
-
-dependencies {
-    testImplementation("org.junit.jupiter:junit-jupiter:5.9.2")
-    testImplementation("com.code-intelligence:jazzer-junit:0.15.0")
 }

--- a/examples/multi-project-android-app/app/src/main/AndroidManifest.xml
+++ b/examples/multi-project-android-app/app/src/main/AndroidManifest.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools">
+
+    <application
+        android:label="App"
+        android:supportsRtl="true"
+        tools:targetApi="31">
+        <activity
+            android:name=".MainActivity"
+            android:exported="true"
+            android:label="App">
+            <intent-filter>
+                <action android:name="android.intent.action.MAIN" />
+
+                <category android:name="android.intent.category.LAUNCHER" />
+            </intent-filter>
+        </activity>
+    </application>
+
+</manifest>

--- a/examples/multi-project-android-app/app/src/main/java/org/example/MainActivity.kt
+++ b/examples/multi-project-android-app/app/src/main/java/org/example/MainActivity.kt
@@ -1,0 +1,11 @@
+package org.example
+
+import android.app.Activity
+import android.os.Bundle
+
+class MainActivity : Activity() {
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+    }
+}
+

--- a/examples/multi-project-android-app/app/src/main/java/org/example/MainFeature.kt
+++ b/examples/multi-project-android-app/app/src/main/java/org/example/MainFeature.kt
@@ -1,0 +1,8 @@
+package org.example
+
+import android.app.Activity
+import android.os.Bundle
+
+class MainFeature  {
+    fun doSomething() = true
+}

--- a/examples/multi-project-android-app/app/src/test/java/org/example/ExampleUnitTest.kt
+++ b/examples/multi-project-android-app/app/src/test/java/org/example/ExampleUnitTest.kt
@@ -1,0 +1,20 @@
+package org.example
+
+import com.code_intelligence.jazzer.junit.FuzzTest
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+
+
+class ExampleUnitTest {
+
+    @FuzzTest
+    fun fuzzTest(data: ByteArray) {
+        assertTrue(MainFeature().doSomething())
+    }
+
+    @Test
+    fun addition_isCorrect() {
+        assertEquals(4, 2 + 2)
+    }
+}

--- a/examples/multi-project-android-app/app/src/test/java/org/example/ExampleUnitTest.kt
+++ b/examples/multi-project-android-app/app/src/test/java/org/example/ExampleUnitTest.kt
@@ -5,7 +5,6 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertTrue
 
-
 class ExampleUnitTest {
 
     @FuzzTest
@@ -14,7 +13,7 @@ class ExampleUnitTest {
     }
 
     @Test
-    fun addition_isCorrect() {
+    fun unitTest() {
         assertEquals(4, 2 + 2)
     }
 }

--- a/examples/multi-project-android-app/build.gradle.kts
+++ b/examples/multi-project-android-app/build.gradle.kts
@@ -1,4 +1,4 @@
 plugins {
-    id("com.android.application") version "7.4.2" apply false
-    id("org.jetbrains.kotlin.android") version "1.8.20"  apply false
+    id("com.android.application") apply false
+    id("org.jetbrains.kotlin.android") apply false
 }

--- a/examples/multi-project-android-app/build.gradle.kts
+++ b/examples/multi-project-android-app/build.gradle.kts
@@ -1,0 +1,4 @@
+plugins {
+    id("com.android.application") version "7.4.2" apply false
+    id("org.jetbrains.kotlin.android") version "1.8.20"  apply false
+}

--- a/examples/multi-project-android-app/gradle.properties
+++ b/examples/multi-project-android-app/gradle.properties
@@ -1,0 +1,2 @@
+android.useAndroidX=true
+org.gradle.jvmargs=-Xmx2g

--- a/examples/multi-project-android-app/lib/build.gradle.kts
+++ b/examples/multi-project-android-app/lib/build.gradle.kts
@@ -1,21 +1,15 @@
 plugins {
-    id("com.android.application")
+    id("com.android.library")
     id("org.jetbrains.kotlin.android")
-    id("com.code-intelligence.cifuzz") version "dev"
 }
 
-// cifuzz.androidVariant.set("debug")
-
 android {
-    namespace = "org.example"
+    namespace = "org.example.lib"
     compileSdk = 33
 
     defaultConfig {
-        applicationId = "org.example"
         minSdk = 24
         targetSdk = 33
-        versionCode = 1
-        versionName = "1.0"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }
@@ -27,8 +21,4 @@ android {
     kotlinOptions {
         jvmTarget = "1.8"
     }
-}
-
-dependencies {
-    implementation(project(":lib"))
 }

--- a/examples/multi-project-android-app/lib/src/main/AndroidManifest.xml
+++ b/examples/multi-project-android-app/lib/src/main/AndroidManifest.xml
@@ -1,0 +1,3 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest>
+</manifest>

--- a/examples/multi-project-android-app/lib/src/main/java/org/example/lib/Lib.kt
+++ b/examples/multi-project-android-app/lib/src/main/java/org/example/lib/Lib.kt
@@ -1,0 +1,5 @@
+package org.example.lib
+
+class Lib {
+    fun runLib() = true
+}

--- a/examples/multi-project-android-app/settings.gradle.kts
+++ b/examples/multi-project-android-app/settings.gradle.kts
@@ -2,6 +2,11 @@ pluginManagement {
     includeBuild("../..")
     repositories.google()
     repositories.gradlePluginPortal()
+
+    plugins {
+        id("com.android.application") version "7.4.2"
+        id("org.jetbrains.kotlin.android") version "1.8.20"
+    }
 }
 
 dependencyResolutionManagement {

--- a/examples/multi-project-android-app/settings.gradle.kts
+++ b/examples/multi-project-android-app/settings.gradle.kts
@@ -1,0 +1,7 @@
+pluginManagement {
+    includeBuild("../..")
+    repositories.google()
+    repositories.gradlePluginPortal()
+}
+
+include("app")

--- a/examples/multi-project-android-app/settings.gradle.kts
+++ b/examples/multi-project-android-app/settings.gradle.kts
@@ -4,4 +4,12 @@ pluginManagement {
     repositories.gradlePluginPortal()
 }
 
+dependencyResolutionManagement {
+    repositories {
+        google()
+        mavenCentral()
+    }
+}
+
 include("app")
+include("lib")

--- a/examples/multi-project/module-c/build.gradle.kts
+++ b/examples/multi-project/module-c/build.gradle.kts
@@ -1,6 +1,6 @@
 plugins {
     id("java-library")
-    id("com.code-intelligence.cifuzz")
+    id("com.code-intelligence.cifuzz") version "dev"
 }
 
 repositories.mavenCentral()

--- a/examples/single-project-custom-test-task/build.gradle.kts
+++ b/examples/single-project-custom-test-task/build.gradle.kts
@@ -1,5 +1,5 @@
 plugins {
-    id("com.code-intelligence.cifuzz")
+    id("com.code-intelligence.cifuzz") version "dev"
     id("java-library")
 }
 

--- a/examples/single-project-groovy/build.gradle
+++ b/examples/single-project-groovy/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id 'com.code-intelligence.cifuzz'
+    id 'com.code-intelligence.cifuzz' version 'dev'
     id 'java-library'
     id 'groovy'
 }

--- a/examples/single-project-kotlin/build.gradle.kts
+++ b/examples/single-project-kotlin/build.gradle.kts
@@ -1,5 +1,5 @@
 plugins {
-    id("com.code-intelligence.cifuzz")
+    id("com.code-intelligence.cifuzz") version "dev"
     id("java-library")
     id("org.jetbrains.kotlin.jvm") version "1.6.21"
 }

--- a/examples/single-project-kotlin/settings.gradle.kts
+++ b/examples/single-project-kotlin/settings.gradle.kts
@@ -1,1 +1,4 @@
-pluginManagement { includeBuild("../..") }
+pluginManagement {
+    includeBuild("../..")
+    repositories.gradlePluginPortal()
+}

--- a/examples/single-project-multiple-test-sets/build.gradle.kts
+++ b/examples/single-project-multiple-test-sets/build.gradle.kts
@@ -1,5 +1,5 @@
 plugins {
-    id("com.code-intelligence.cifuzz")
+    id("com.code-intelligence.cifuzz") version "dev"
     id("java-library")
 }
 

--- a/examples/single-project-scala/build.gradle.kts
+++ b/examples/single-project-scala/build.gradle.kts
@@ -1,5 +1,5 @@
 plugins {
-    id("com.code-intelligence.cifuzz")
+    id("com.code-intelligence.cifuzz") version "dev"
     id("java-library")
     id("scala")
 }

--- a/examples/single-project/build.gradle.kts
+++ b/examples/single-project/build.gradle.kts
@@ -1,5 +1,5 @@
 plugins {
-    id("com.code-intelligence.cifuzz")
+    id("com.code-intelligence.cifuzz") version "dev"
     id("java-library")
 }
 

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -4,6 +4,7 @@ plugins {
 
 dependencyResolutionManagement {
     repositories.gradlePluginPortal()
+    repositories.google()
 }
 
 gradleEnterprise {

--- a/src/main/kotlin/com/code_intelligence/cifuzz/CIFuzzExtension.kt
+++ b/src/main/kotlin/com/code_intelligence/cifuzz/CIFuzzExtension.kt
@@ -19,4 +19,9 @@ interface CIFuzzExtension {
      * Configures the task that executes the fuzz tests - defaults to the task with the same name as the source set.
      */
     val testTask: Property<Test>
+
+    /**
+     * Configure the source set that contains the production code under tests – defaults to 'sourceSets.main'.
+     */
+    val mainSourceSet: Property<SourceSet>
 }

--- a/src/main/kotlin/com/code_intelligence/cifuzz/CIFuzzPlugin.kt
+++ b/src/main/kotlin/com/code_intelligence/cifuzz/CIFuzzPlugin.kt
@@ -1,5 +1,6 @@
 package com.code_intelligence.cifuzz
 
+import com.code_intelligence.cifuzz.android.registerCIFuzzAndroidExtensionAndConfigure
 import com.code_intelligence.cifuzz.config.configureCIFuzzPlugin
 import org.gradle.api.Plugin
 import org.gradle.api.Project
@@ -23,6 +24,10 @@ abstract class CIFuzzPlugin : Plugin<Project> {
         project.plugins.withId("java") {
             val cifuzz = project.registerCIFuzzExtension()
             project.configureCIFuzzPlugin(StandardJvmTestSetAccess(cifuzz))
+        }
+        project.plugins.withId("com.android.base") {
+            project.registerCIFuzzAndroidExtensionAndConfigure()
+            // the above registers a callback to 'configureCIFuzzPlugin(...)'
         }
     }
 

--- a/src/main/kotlin/com/code_intelligence/cifuzz/CIFuzzPlugin.kt
+++ b/src/main/kotlin/com/code_intelligence/cifuzz/CIFuzzPlugin.kt
@@ -1,33 +1,17 @@
 package com.code_intelligence.cifuzz
 
-import com.code_intelligence.cifuzz.tasks.BuildDirectoryPrinter
-import com.code_intelligence.cifuzz.tasks.PluginVersionPrinter
-import com.code_intelligence.cifuzz.tasks.ClasspathPrinter
-import com.code_intelligence.cifuzz.tasks.PackagesPrinter
+import com.code_intelligence.cifuzz.config.configureCIFuzzPlugin
 import org.gradle.api.Plugin
 import org.gradle.api.Project
-import org.gradle.api.artifacts.component.ProjectComponentIdentifier
-import org.gradle.api.attributes.LibraryElements
-import org.gradle.api.file.FileCollection
-import org.gradle.api.provider.Provider
-import org.gradle.api.reporting.ReportingExtension
 import org.gradle.api.tasks.SourceSet
 import org.gradle.api.tasks.SourceSetContainer
-import org.gradle.api.tasks.TaskProvider
 import org.gradle.api.tasks.testing.Test
-import org.gradle.testing.jacoco.plugins.JacocoCoverageReport
-import org.gradle.testing.jacoco.plugins.JacocoTaskExtension
-import org.gradle.testing.jacoco.tasks.JacocoReport
 import org.gradle.util.GradleVersion
-import java.io.File
 
 @Suppress("unused")
 abstract class CIFuzzPlugin : Plugin<Project> {
 
     private val isSupportedGradleVersion = GradleVersion.current() >= GradleVersion.version("6.1")
-    private val isGradleVersionWithTestSuitesSupport = GradleVersion.current() >= GradleVersion.version("7.4")
-    private val jazzerVersion = "0.16.1"
-    private val jazzerJUnit5TestTag = "jazzer"
 
     override fun apply(project: Project) {
         if (!isSupportedGradleVersion) {
@@ -37,204 +21,21 @@ abstract class CIFuzzPlugin : Plugin<Project> {
         // The plugin relies on the 'java' plugin being applied first, which is implicitly applied by plugins like:
         // 'application', 'java-library', 'groovy', 'scala', 'kotlin("jvm")', ...
         project.plugins.withId("java") {
-            project.configureCIFuzzPlugin()
+            val cifuzz = project.registerCIFuzzExtension()
+            project.configureCIFuzzPlugin(StandardJvmTestSetAccess(cifuzz))
         }
     }
-    private fun Project.configureCIFuzzPlugin() {
-        val fuzzTestProperty = gradleProperty("cifuzz.fuzztest")
-        
+
+    private fun Project.registerCIFuzzExtension() = extensions.create("cifuzz", CIFuzzExtension::class.java).apply {
         // Register extension for fine-tuning - can be used in 'build.gradle' files like this:
         //   cifuzz {
         //     testSourceSet.set(customFuzzTestSourceSet)
         //     testTask.set(customFuzzTestTask)
         //   }
-        val cifuzz = registerCIFuzzExtension()
-        
-        // Register cifuzz help tasks
-        registerPrintCIFuzzPluginVersion()
-        registerPrintBuildDir()
-        registerPrintClasspath(cifuzz.testSourceSet)
-        registerPrintPackages(cifuzz.testSourceSet)
-
-        // Automatically add dependencies to Jazzer
-        addJazzerDependencies(cifuzz.testSourceSet)
-
-        // The test task selected for fuzz testing is only (re)configured when started through 'cifuzz' for coverage
-        // to keep normal Gradle test execution untouched.
-        if (fuzzTestProperty != null) {
-            reconfigureTestTasks(cifuzz.testTask, fuzzTestProperty)
-        }
-
-        // Register a custom JacocoReport task to avoid side effects on existing user tasks when overwriting config
-        // values (like the output path).
-        if (isGradleVersionWithTestSuitesSupport) {
-            registerCoverageReportingTask(cifuzz.testTask)
-        } else {
-            registerCoverageReportingTaskLegacy(cifuzz.testTask, cifuzz.testSourceSet)
-        }
-    }
-
-    private fun Project.registerCIFuzzExtension() = extensions.create("cifuzz", CIFuzzExtension::class.java).apply {
         val sourceSets = extensions.getByType(SourceSetContainer::class.java)
-        
+
         testSourceSet.convention(sourceSets.getByName(SourceSet.TEST_SOURCE_SET_NAME))
+        mainSourceSet.convention(sourceSets.getByName(SourceSet.MAIN_SOURCE_SET_NAME))
         testTask.convention(testSourceSet.flatMap { sourceSet -> tasks.named(sourceSet.name, Test::class.java) })
-    }
-    
-    private fun Project.registerPrintCIFuzzPluginVersion() {
-        tasks.register("cifuzzPrintPluginVersion", PluginVersionPrinter::class.java)
-    }
-
-    private fun Project.registerPrintBuildDir() {
-        tasks.register("cifuzzPrintBuildDir", BuildDirectoryPrinter::class.java) { printBuildDir ->
-            printBuildDir.buildDirectory.set(layout.buildDirectory.map { it.asFile.absolutePath })
-        }
-    }
-
-    private fun Project.registerPrintClasspath(testSourceSet: Provider<SourceSet>) {
-        tasks.register("cifuzzPrintTestClasspath", ClasspathPrinter::class.java) { printClasspath ->
-            printClasspath.testRuntimeClasspath.from(testSourceSet.get().runtimeClasspath)
-        }
-    }
-
-    private fun Project.registerPrintPackages(testSourceSet: Provider<SourceSet>) {
-        tasks.register("cifuzzPrintPackages", PackagesPrinter::class.java) { printClasspath ->
-            printClasspath.testRuntimeClasspath.from(mainSourceSet().output)
-            printClasspath.testRuntimeClasspath.from(classesFolderView(testSourceSet))
-        }
-    }
-
-    private fun Project.addJazzerDependencies(testSourceSet: Provider<SourceSet>) {
-        configurations.all { configuration ->
-            // Use 'withDependencies { }' to access 'testSourceSet.get()' at the latest point possible.
-            configuration.withDependencies { dependencySet ->
-                val sourceSet = testSourceSet.get()
-                if (configuration.name == sourceSet.implementationConfigurationName) {
-                    // To write fuzz tests, add 'jazzer-junit' to 'implementation' scope of the selected source set.
-                    // Jazzer brings in the JUnit5 API with a defined version.
-                    dependencySet.add(dependencies.create("com.code-intelligence:jazzer-junit:$jazzerVersion"))
-                }
-                if (configuration.name == sourceSet.runtimeOnlyConfigurationName) {
-                    // To run the tests, add 'junit-jupiter-engine' to 'runtimeOnly' scope of the selected source set.
-                    // Add it without version - the version is automatically aligned with the JUnit 5 API.
-                    dependencySet.add(dependencies.create("org.junit.jupiter:junit-jupiter-engine"))
-                }
-            }
-        }
-    }
-
-    private fun Project.reconfigureTestTasks(testTaskProvider: Provider<Test>, fuzzTestFilter: String) {
-        tasks.withType(Test::class.java).configureEach { testTask ->
-            // Only configure the test task that runs the fuzz tests
-            if (testTask == testTaskProvider.get()) {
-                // The task needs to use JUnit5 (useJUnitPlatform) and should only run @FuzzTest Jazzer tests
-                // (and no normal @Test tests).
-                testTask.useJUnitPlatform {
-                    it.includeTags = setOf(jazzerJUnit5TestTag)
-                }
-
-                testTask.ignoreFailures = true // Do not fail the build if a test fails
-                testTask.jvmArgs("-Djazzer.hooks=false") // disable Jazzer hooks as they are not needed for coverage
-
-                testTask.filter { filter ->
-                    filter.includeTestsMatching(fuzzTestFilter) // Only include the fuzz test(s) specified by 'cifuzz'
-                    filter.isFailOnNoMatchingTests = false // Do not fail the build if the test does not exist
-                }
-            }
-        }
-    }
-
-    private fun Project.registerCoverageReportingTask(testTask: Provider<Test>) {
-        plugins.apply("jacoco-report-aggregation") // This plugin was added in Gradle 7.4
-
-        val reporting = extensions.getByType(ReportingExtension::class.java)
-
-        // Register a new JacocoCoverageReport which will automatically add a task and configure it to pick up
-        // source code and classes from all dependencies, which is required in a multi-project setup.
-        reporting.reports.register("cifuzzReport", JacocoCoverageReport::class.java) { report ->
-            report.testType.convention("undefined") // Gradle 7.x requires this to not fail test classpath resolution
-            configureJacocoReportTask(report.reportTask, testTask)
-        }
-    }
-
-    private fun Project.registerCoverageReportingTaskLegacy(testTask: Provider<Test>,
-                                                            testSourceSet: Provider<SourceSet>) {
-        plugins.apply("jacoco")
-
-        // Directly register a JacocoReport task, as JacocoCoverageReport (see above) is not available in Gradle
-        // versions older than 7.4.
-        val reportTask = tasks.register("cifuzzReport", JacocoReport::class.java) { cifuzzReport ->
-            val classesFolders = classesFolderView(testSourceSet)
-
-            // Add sources and classes (compiled code) from the CURRENT project
-            cifuzzReport.classDirectories.from(mainSourceSet().output)
-            cifuzzReport.sourceDirectories.from(mainSourceSet().java.srcDirs)
-
-            // Add sources and classes (compiled code) from other projects the project depends on
-            cifuzzReport.classDirectories.from(classesFolders)
-            cifuzzReport.sourceDirectories.from(classesFolders.elements.map { classFolders ->
-                // Because the other projects do not always export their source code (before Gradle 7.4), we make the
-                // assumption that we can find it in a location relative to the classes.
-                classFolders.map {
-                    val classFolder = it.asFile
-                    val sourceSet = classFolder.name // usually 'main'
-                    val jvmLanguage = classFolder.parentFile.name // usually 'java'
-                    val projectRoot = classFolder.parentFile.parentFile.parentFile.parentFile
-                    File(projectRoot, "$sourceSet/$jvmLanguage")
-                }
-            })
-        }
-
-        configureJacocoReportTask(reportTask, testTask)
-    }
-
-    private fun Project.configureJacocoReportTask(reportTask: TaskProvider<JacocoReport>,
-                                                  testTask: Provider<Test>) {
-        reportTask.configure { cifuzzReport ->
-            // Take the execution data from the fuzz test task.
-            // This adds a dependency to the task so that it will run before and produce the data.
-            cifuzzReport.executionData.setFrom(testTask.map { testTask ->
-                testTask.extensions.getByType(JacocoTaskExtension::class.java).destinationFile!!
-            })
-
-            cifuzzReport.reports { reports ->
-                // Configure which reports are produced, which can be influenced by 'cifuzz' through a Gradle property.
-                val format = gradleProperty("cifuzz.report.format") ?: "html"
-                reports.html.required.set(format != "jacocoxml")
-                reports.xml.required.set(true)
-
-                // Configure where the reports go, which can be influenced by 'cifuzz' through a Gradle property.
-                val output = gradleProperty("cifuzz.report.output")
-                if (output != null) {
-                    reports.html.outputLocation.set(layout.projectDirectory.dir("$output/html"))
-                    reports.xml.outputLocation.set(layout.projectDirectory.file("$output/jacoco.xml"))
-                }
-            }
-        }
-    }
-
-    private fun Project.classesFolderView(testSourceSet: Provider<SourceSet>): FileCollection {
-        val testRuntimeClasspath = configurations.getByName(testSourceSet.get().runtimeClasspathConfigurationName)
-
-        // Get access to all 'classes' folders (compiled code) of dependencies through dependency management.
-        return testRuntimeClasspath.incoming.artifactView { view ->
-                view.componentFilter { id -> id is ProjectComponentIdentifier }
-                view.attributes.attribute(
-                    LibraryElements.LIBRARY_ELEMENTS_ATTRIBUTE, objects.named(
-                        LibraryElements::class.java, LibraryElements.CLASSES
-                    )
-                )
-            }.files
-    }
-
-    private fun Project.mainSourceSet(): SourceSet =
-        extensions.getByType(SourceSetContainer::class.java).getByName("main")
-
-    private fun Project.gradleProperty(name: String): String? = if (isGradleVersionWithTestSuitesSupport) {
-        providers.gradleProperty(name).orNull
-    } else {
-        // Fallback for older Gradle versions that either do not have 'Providers.gradleProperty' or require the
-        // now deprecated 'Provider.forUseAtConfigurationTime()'.
-        findProperty(name) as String?
     }
 }

--- a/src/main/kotlin/com/code_intelligence/cifuzz/StandardJvmTestSetAccess.kt
+++ b/src/main/kotlin/com/code_intelligence/cifuzz/StandardJvmTestSetAccess.kt
@@ -1,0 +1,31 @@
+package com.code_intelligence.cifuzz
+
+import org.gradle.api.file.FileCollection
+import org.gradle.api.provider.Provider
+import org.gradle.api.tasks.testing.Test
+
+class StandardJvmTestSetAccess(
+    private val ciFuzz: CIFuzzExtension
+) : TestSetAccess {
+
+    override val testRuntimeClasspath: FileCollection
+        get() = ciFuzz.testSourceSet.get().runtimeClasspath
+
+    override val testImplementationConfigurationName: String
+        get() = ciFuzz.testSourceSet.get().implementationConfigurationName
+
+    override val testRuntimeOnlyConfigurationName: String
+        get() = ciFuzz.testSourceSet.get().runtimeOnlyConfigurationName
+
+    override val testRuntimeClasspathConfigurationName: String
+        get() = ciFuzz.testSourceSet.get().runtimeClasspathConfigurationName
+
+    override val mainClasses: FileCollection
+        get() = ciFuzz.mainSourceSet.get().output
+
+    override val mainSources: FileCollection
+        get() = ciFuzz.mainSourceSet.get().allSource.sourceDirectories
+
+    override val testTask: Provider<Test>
+        get() = ciFuzz.testTask
+}

--- a/src/main/kotlin/com/code_intelligence/cifuzz/StandardJvmTestSetAccess.kt
+++ b/src/main/kotlin/com/code_intelligence/cifuzz/StandardJvmTestSetAccess.kt
@@ -1,8 +1,8 @@
 package com.code_intelligence.cifuzz
 
+import org.gradle.api.Task
 import org.gradle.api.file.FileCollection
 import org.gradle.api.provider.Provider
-import org.gradle.api.tasks.testing.Test
 
 class StandardJvmTestSetAccess(
     private val ciFuzz: CIFuzzExtension
@@ -26,6 +26,6 @@ class StandardJvmTestSetAccess(
     override val mainSources: FileCollection
         get() = ciFuzz.mainSourceSet.get().allSource.sourceDirectories
 
-    override val testTask: Provider<Test>
+    override val testTask: Provider<out Task>
         get() = ciFuzz.testTask
 }

--- a/src/main/kotlin/com/code_intelligence/cifuzz/TestSetAccess.kt
+++ b/src/main/kotlin/com/code_intelligence/cifuzz/TestSetAccess.kt
@@ -1,0 +1,15 @@
+package com.code_intelligence.cifuzz
+
+import org.gradle.api.file.FileCollection
+import org.gradle.api.provider.Provider
+import org.gradle.api.tasks.testing.Test
+
+interface TestSetAccess {
+    val testRuntimeClasspath: FileCollection
+    val testImplementationConfigurationName: String
+    val testRuntimeOnlyConfigurationName: String
+    val testRuntimeClasspathConfigurationName: String
+    val mainClasses: FileCollection
+    val mainSources: FileCollection
+    val testTask: Provider<Test>
+}

--- a/src/main/kotlin/com/code_intelligence/cifuzz/TestSetAccess.kt
+++ b/src/main/kotlin/com/code_intelligence/cifuzz/TestSetAccess.kt
@@ -1,8 +1,8 @@
 package com.code_intelligence.cifuzz
 
+import org.gradle.api.Task
 import org.gradle.api.file.FileCollection
 import org.gradle.api.provider.Provider
-import org.gradle.api.tasks.testing.Test
 
 interface TestSetAccess {
     val testRuntimeClasspath: FileCollection
@@ -11,5 +11,5 @@ interface TestSetAccess {
     val testRuntimeClasspathConfigurationName: String
     val mainClasses: FileCollection
     val mainSources: FileCollection
-    val testTask: Provider<Test>
+    val testTask: Provider<out Task>
 }

--- a/src/main/kotlin/com/code_intelligence/cifuzz/android/AndroidBridge.kt
+++ b/src/main/kotlin/com/code_intelligence/cifuzz/android/AndroidBridge.kt
@@ -14,17 +14,6 @@ internal fun Project.registerCIFuzzAndroidExtensionAndConfigure() {
             if (variant.name == androidVariant.get()) {
                 configureCIFuzzPlugin(AndroidTestSetAccess(project, variant, UnitTest::class.java))
                     // if (androidTest.get()) AndroidTest::class.java else UnitTest::class.java))
-
-                tasks.configureEach {
-                    val unitTest = variant.unitTest
-                    if (unitTest != null && it.name == "compile${unitTest.name.capitalized()}Kotlin") {
-                        val bundleClassesToCompileJarTask = "bundle${variant.name.capitalized()}ClassesToCompileJar"
-                        if (tasks.names.contains(bundleClassesToCompileJarTask)) {
-                            // TODO figure out why 'cifuzzPrintTestClasspath' causes an error without this
-                            it.dependsOn(tasks.named(bundleClassesToCompileJarTask))
-                        }
-                    }
-                }
             }
         }
     }

--- a/src/main/kotlin/com/code_intelligence/cifuzz/android/AndroidBridge.kt
+++ b/src/main/kotlin/com/code_intelligence/cifuzz/android/AndroidBridge.kt
@@ -8,19 +8,22 @@ import org.gradle.api.Project
 import java.util.Locale
 
 internal fun Project.registerCIFuzzAndroidExtensionAndConfigure() {
-    project.extensions.create("cifuzz", CIFuzzAndroidExtension::class.java).apply {
+    extensions.create("cifuzz", CIFuzzAndroidExtension::class.java).apply {
         androidVariant.convention("release")
         androidTest.convention(false) // false == UnitTest
         extensions.getByType(AndroidComponentsExtension::class.java).onVariants { variant ->
             if (variant.name == androidVariant.get()) {
-                project.configureCIFuzzPlugin(AndroidTestSetAccess(project, variant,
+                configureCIFuzzPlugin(AndroidTestSetAccess(project, variant,
                     if (androidTest.get()) AndroidTest::class.java else UnitTest::class.java))
 
                 tasks.configureEach {
                     val unitTest = variant.unitTest
                     if (unitTest != null && it.name == "compile${unitTest.name.capitalized()}Kotlin") {
-                        // TODO figure out why 'cifuzzPrintTestClasspath' causes an error without this
-                        it.dependsOn(project.tasks.named("bundle${variant.name.capitalized()}ClassesToCompileJar"))
+                        val bundleClassesToCompileJarTask = "bundle${variant.name.capitalized()}ClassesToCompileJar"
+                        if (tasks.names.contains(bundleClassesToCompileJarTask)) {
+                            // TODO figure out why 'cifuzzPrintTestClasspath' causes an error without this
+                            it.dependsOn(tasks.named(bundleClassesToCompileJarTask))
+                        }
                     }
                 }
             }

--- a/src/main/kotlin/com/code_intelligence/cifuzz/android/AndroidBridge.kt
+++ b/src/main/kotlin/com/code_intelligence/cifuzz/android/AndroidBridge.kt
@@ -1,7 +1,6 @@
 package com.code_intelligence.cifuzz.android
 
 import com.android.build.api.variant.AndroidComponentsExtension
-import com.android.build.api.variant.AndroidTest
 import com.android.build.api.variant.UnitTest
 import com.code_intelligence.cifuzz.config.configureCIFuzzPlugin
 import org.gradle.api.Project
@@ -10,11 +9,11 @@ import java.util.Locale
 internal fun Project.registerCIFuzzAndroidExtensionAndConfigure() {
     extensions.create("cifuzz", CIFuzzAndroidExtension::class.java).apply {
         androidVariant.convention("release")
-        androidTest.convention(false) // false == UnitTest
+        // androidTest.convention(false) // false == UnitTest
         extensions.getByType(AndroidComponentsExtension::class.java).onVariants { variant ->
             if (variant.name == androidVariant.get()) {
-                configureCIFuzzPlugin(AndroidTestSetAccess(project, variant,
-                    if (androidTest.get()) AndroidTest::class.java else UnitTest::class.java))
+                configureCIFuzzPlugin(AndroidTestSetAccess(project, variant, UnitTest::class.java))
+                    // if (androidTest.get()) AndroidTest::class.java else UnitTest::class.java))
 
                 tasks.configureEach {
                     val unitTest = variant.unitTest

--- a/src/main/kotlin/com/code_intelligence/cifuzz/android/AndroidBridge.kt
+++ b/src/main/kotlin/com/code_intelligence/cifuzz/android/AndroidBridge.kt
@@ -5,9 +5,9 @@ import com.android.build.api.variant.AndroidTest
 import com.android.build.api.variant.UnitTest
 import com.code_intelligence.cifuzz.config.configureCIFuzzPlugin
 import org.gradle.api.Project
-import org.gradle.configurationcache.extensions.capitalized
+import java.util.Locale
 
-fun Project.registerCIFuzzAndroidExtensionAndConfigure() {
+internal fun Project.registerCIFuzzAndroidExtensionAndConfigure() {
     project.extensions.create("cifuzz", CIFuzzAndroidExtension::class.java).apply {
         androidVariant.convention("release")
         androidTest.convention(false) // false == UnitTest
@@ -27,3 +27,14 @@ fun Project.registerCIFuzzAndroidExtensionAndConfigure() {
         }
     }
 }
+
+internal fun CharSequence.capitalized(): String =
+    when {
+        isEmpty() -> ""
+        else -> get(0).let { initial ->
+            when {
+                initial.isLowerCase() -> initial.titlecase(Locale.getDefault()) + substring(1)
+                else -> toString()
+            }
+        }
+    }

--- a/src/main/kotlin/com/code_intelligence/cifuzz/android/AndroidBridge.kt
+++ b/src/main/kotlin/com/code_intelligence/cifuzz/android/AndroidBridge.kt
@@ -1,0 +1,29 @@
+package com.code_intelligence.cifuzz.android
+
+import com.android.build.api.variant.AndroidComponentsExtension
+import com.android.build.api.variant.AndroidTest
+import com.android.build.api.variant.UnitTest
+import com.code_intelligence.cifuzz.config.configureCIFuzzPlugin
+import org.gradle.api.Project
+import org.gradle.configurationcache.extensions.capitalized
+
+fun Project.registerCIFuzzAndroidExtensionAndConfigure() {
+    project.extensions.create("cifuzz", CIFuzzAndroidExtension::class.java).apply {
+        androidVariant.convention("release")
+        androidTest.convention(false) // false == UnitTest
+        extensions.getByType(AndroidComponentsExtension::class.java).onVariants { variant ->
+            if (variant.name == androidVariant.get()) {
+                project.configureCIFuzzPlugin(AndroidTestSetAccess(project, variant,
+                    if (androidTest.get()) AndroidTest::class.java else UnitTest::class.java))
+
+                tasks.configureEach {
+                    val unitTest = variant.unitTest
+                    if (unitTest != null && it.name == "compile${unitTest.name.capitalized()}Kotlin") {
+                        // TODO figure out why 'cifuzzPrintTestClasspath' causes an error without this
+                        it.dependsOn(project.tasks.named("bundle${variant.name.capitalized()}ClassesToCompileJar"))
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/main/kotlin/com/code_intelligence/cifuzz/android/AndroidTestSetAccess.kt
+++ b/src/main/kotlin/com/code_intelligence/cifuzz/android/AndroidTestSetAccess.kt
@@ -9,7 +9,6 @@ import org.gradle.api.attributes.Attribute
 import org.gradle.api.file.FileCollection
 import org.gradle.api.provider.Provider
 import org.gradle.api.tasks.testing.Test
-import org.gradle.configurationcache.extensions.capitalized
 
 class AndroidTestSetAccess(
     private val project: Project,

--- a/src/main/kotlin/com/code_intelligence/cifuzz/android/AndroidTestSetAccess.kt
+++ b/src/main/kotlin/com/code_intelligence/cifuzz/android/AndroidTestSetAccess.kt
@@ -5,6 +5,7 @@ import com.android.build.api.variant.UnitTest
 import com.android.build.api.variant.Variant
 import com.code_intelligence.cifuzz.TestSetAccess
 import org.gradle.api.Project
+import org.gradle.api.attributes.Attribute
 import org.gradle.api.file.FileCollection
 import org.gradle.api.provider.Provider
 import org.gradle.api.tasks.testing.Test
@@ -23,7 +24,9 @@ class AndroidTestSetAccess(
     private fun testTaskPrefix() = if (testType == UnitTest::class.java) "test" else "connected"
 
     override val testRuntimeClasspath: FileCollection
-        get() = (testComponent().compileClasspath + testComponent().runtimeConfiguration)
+        get() = (testComponent().compileClasspath + testComponent().runtimeConfiguration.incoming.artifactView {
+            it.attributes.attribute(Attribute.of("artifactType", String::class.java), "android-classes-jar")
+        }.files)
 
     override val testImplementationConfigurationName: String
         get() = "${testConfigurationPrefix()}Implementation"

--- a/src/main/kotlin/com/code_intelligence/cifuzz/android/AndroidTestSetAccess.kt
+++ b/src/main/kotlin/com/code_intelligence/cifuzz/android/AndroidTestSetAccess.kt
@@ -1,0 +1,45 @@
+package com.code_intelligence.cifuzz.android
+
+import com.android.build.api.variant.TestComponent
+import com.android.build.api.variant.UnitTest
+import com.android.build.api.variant.Variant
+import com.code_intelligence.cifuzz.TestSetAccess
+import org.gradle.api.Project
+import org.gradle.api.file.FileCollection
+import org.gradle.api.provider.Provider
+import org.gradle.api.tasks.testing.Test
+import org.gradle.configurationcache.extensions.capitalized
+
+class AndroidTestSetAccess(
+    private val project: Project,
+    private val selectedVariant: Variant,
+    private val testType: Class<out TestComponent>
+) : TestSetAccess {
+
+    private fun testComponent() = selectedVariant.nestedComponents.find { testType.isAssignableFrom(it.javaClass) }!! // TODO give proper error if tests of given type do not exist
+
+    private fun testConfigurationPrefix() = if (testType == UnitTest::class.java) "test" else "androidTest"
+
+    private fun testTaskPrefix() = if (testType == UnitTest::class.java) "test" else "connected"
+
+    override val testRuntimeClasspath: FileCollection
+        get() = (testComponent().compileClasspath + testComponent().runtimeConfiguration)
+
+    override val testImplementationConfigurationName: String
+        get() = "${testConfigurationPrefix()}Implementation"
+
+    override val testRuntimeOnlyConfigurationName: String
+        get() = "${testConfigurationPrefix()}RuntimeOnly"
+
+    override val testRuntimeClasspathConfigurationName: String
+        get() = testComponent().runtimeConfiguration.name
+
+    override val mainClasses: FileCollection
+        get() = project.objects.fileCollection() // the classes are part of the 'testRuntimeClasspathConfiguration' already
+
+    override val mainSources: FileCollection
+        get() = project.objects.fileCollection().from(selectedVariant.sources.java?.all, selectedVariant.sources.kotlin?.all)
+
+    override val testTask: Provider<Test>
+        get() = project.provider { project.tasks.named("${testTaskPrefix()}${testComponent().name.capitalized()}", Test::class.java) }.flatMap { it }
+}

--- a/src/main/kotlin/com/code_intelligence/cifuzz/android/CIFuzzAndroidExtension.kt
+++ b/src/main/kotlin/com/code_intelligence/cifuzz/android/CIFuzzAndroidExtension.kt
@@ -1,0 +1,12 @@
+package com.code_intelligence.cifuzz.android
+
+import org.gradle.api.provider.Property
+
+/**
+ * Configuration options for custom Gradle test setup.
+ * This can be used to configure that fuzz tests are NOT located in the default source set (src/test).
+ */
+interface CIFuzzAndroidExtension {
+    val androidVariant: Property<String>
+    val androidTest: Property<Boolean>
+}

--- a/src/main/kotlin/com/code_intelligence/cifuzz/android/CIFuzzAndroidExtension.kt
+++ b/src/main/kotlin/com/code_intelligence/cifuzz/android/CIFuzzAndroidExtension.kt
@@ -3,10 +3,15 @@ package com.code_intelligence.cifuzz.android
 import org.gradle.api.provider.Property
 
 /**
- * Configuration options for custom Gradle test setup.
+ * Configuration options for custom Gradle test setup of Android projects.
  * This can be used to configure that fuzz tests are NOT located in the default source set (src/test).
  */
 interface CIFuzzAndroidExtension {
+    /**
+     * The 'Android Variant' for which to run the fuzz tests (e.g. 'release', 'fullDebug').
+     * The default is 'release'.
+     */
     val androidVariant: Property<String>
-    val androidTest: Property<Boolean>
+
+    // val androidTest: Property<Boolean>
 }

--- a/src/main/kotlin/com/code_intelligence/cifuzz/config/TaskConfigurations.kt
+++ b/src/main/kotlin/com/code_intelligence/cifuzz/config/TaskConfigurations.kt
@@ -7,6 +7,7 @@ import com.code_intelligence.cifuzz.tasks.ClasspathPrinter
 import com.code_intelligence.cifuzz.tasks.PackagesPrinter
 import com.code_intelligence.cifuzz.tasks.PluginVersionPrinter
 import org.gradle.api.Project
+import org.gradle.api.Task
 import org.gradle.api.artifacts.component.ProjectComponentIdentifier
 import org.gradle.api.attributes.LibraryElements
 import org.gradle.api.file.FileCollection
@@ -92,7 +93,7 @@ private fun Project.addJazzerDependencies(testSetAccess: TestSetAccess) {
     }
 }
 
-private fun Project.reconfigureTestTasks(testTaskProvider: Provider<Test>, fuzzTestFilter: String) {
+private fun Project.reconfigureTestTasks(testTaskProvider: Provider<out Task>, fuzzTestFilter: String) {
     tasks.withType(Test::class.java).configureEach { testTask ->
         // Only configure the test task that runs the fuzz tests
         if (testTask == testTaskProvider.get()) {
@@ -113,7 +114,7 @@ private fun Project.reconfigureTestTasks(testTaskProvider: Provider<Test>, fuzzT
     }
 }
 
-private fun Project.registerCoverageReportingTask(testTask: Provider<Test>) {
+private fun Project.registerCoverageReportingTask(testTask: Provider<out Task>) {
     plugins.apply("jacoco-report-aggregation") // This plugin was added in Gradle 7.4
 
     val reporting = extensions.getByType(ReportingExtension::class.java)
@@ -157,7 +158,7 @@ private fun Project.registerCoverageReportingTaskLegacy(testSetAccess: TestSetAc
 }
 
 private fun Project.configureJacocoReportTask(reportTask: TaskProvider<JacocoReport>,
-                                              testTask: Provider<Test>
+                                              testTask: Provider<out Task>
 ) {
     reportTask.configure { cifuzzReport ->
         // Take the execution data from the fuzz test task.

--- a/src/main/kotlin/com/code_intelligence/cifuzz/config/TaskConfigurations.kt
+++ b/src/main/kotlin/com/code_intelligence/cifuzz/config/TaskConfigurations.kt
@@ -1,0 +1,208 @@
+package com.code_intelligence.cifuzz.config
+
+import com.code_intelligence.cifuzz.CIFuzzExtension
+import com.code_intelligence.cifuzz.StandardJvmTestSetAccess
+import com.code_intelligence.cifuzz.TestSetAccess
+import com.code_intelligence.cifuzz.tasks.BuildDirectoryPrinter
+import com.code_intelligence.cifuzz.tasks.ClasspathPrinter
+import com.code_intelligence.cifuzz.tasks.PackagesPrinter
+import com.code_intelligence.cifuzz.tasks.PluginVersionPrinter
+import org.gradle.api.Project
+import org.gradle.api.artifacts.component.ProjectComponentIdentifier
+import org.gradle.api.attributes.LibraryElements
+import org.gradle.api.file.FileCollection
+import org.gradle.api.provider.Provider
+import org.gradle.api.reporting.ReportingExtension
+import org.gradle.api.tasks.SourceSet
+import org.gradle.api.tasks.SourceSetContainer
+import org.gradle.api.tasks.TaskProvider
+import org.gradle.api.tasks.testing.Test
+import org.gradle.testing.jacoco.plugins.JacocoCoverageReport
+import org.gradle.testing.jacoco.plugins.JacocoTaskExtension
+import org.gradle.testing.jacoco.tasks.JacocoReport
+import org.gradle.util.GradleVersion
+import java.io.File
+
+private val isGradleVersionWithTestSuitesSupport = GradleVersion.current() >= GradleVersion.version("7.4")
+private const val JAZZER_VERSION = "0.16.1"
+private const val JAZZER_JUNIT5_TEST_TAG = "jazzer"
+
+internal fun Project.configureCIFuzzPlugin(testSetAccess: TestSetAccess) {
+    val fuzzTestProperty = gradleProperty("cifuzz.fuzztest")
+
+    // Register cifuzz help tasks
+    registerPrintCIFuzzPluginVersion()
+    registerPrintBuildDir()
+    registerPrintClasspath(testSetAccess)
+    registerPrintPackages(testSetAccess)
+
+    // Automatically add dependencies to Jazzer
+    addJazzerDependencies(testSetAccess)
+
+    // The test task selected for fuzz testing is only (re)configured when started through 'cifuzz' for coverage
+    // to keep normal Gradle test execution untouched.
+    if (fuzzTestProperty != null) {
+        reconfigureTestTasks(testSetAccess.testTask, fuzzTestProperty)
+    }
+
+    // Register a custom JacocoReport task to avoid side effects on existing user tasks when overwriting config
+    // values (like the output path).
+    if (isGradleVersionWithTestSuitesSupport && testSetAccess is StandardJvmTestSetAccess) {
+        registerCoverageReportingTask(testSetAccess.testTask)
+    } else {
+        registerCoverageReportingTaskLegacy(testSetAccess)
+    }
+}
+
+private fun Project.registerPrintCIFuzzPluginVersion() {
+    tasks.register("cifuzzPrintPluginVersion", PluginVersionPrinter::class.java)
+}
+
+private fun Project.registerPrintBuildDir() {
+    tasks.register("cifuzzPrintBuildDir", BuildDirectoryPrinter::class.java) { printBuildDir ->
+        printBuildDir.buildDirectory.set(layout.buildDirectory.map { it.asFile.absolutePath })
+    }
+}
+
+private fun Project.registerPrintClasspath(testSetAccess: TestSetAccess) {
+    tasks.register("cifuzzPrintTestClasspath", ClasspathPrinter::class.java) { printClasspath ->
+        printClasspath.testRuntimeClasspath.from(testSetAccess.testRuntimeClasspath)
+    }
+}
+
+private fun Project.registerPrintPackages(testSetAccess: TestSetAccess) {
+    tasks.register("cifuzzPrintPackages", PackagesPrinter::class.java) { printClasspath ->
+        printClasspath.runtimeClasspath.from(testSetAccess.mainClasses)
+        printClasspath.runtimeClasspath.from(classesFolderView(testSetAccess))
+    }
+}
+
+private fun Project.addJazzerDependencies(testSetAccess: TestSetAccess) {
+    configurations.all { configuration ->
+        // Use 'withDependencies { }' to access 'testSourceSet.get()' at the latest point possible.
+        configuration.withDependencies { dependencySet ->
+            if (configuration.name == testSetAccess.testImplementationConfigurationName) {
+                // To write fuzz tests, add 'jazzer-junit' to 'implementation' scope of the selected source set.
+                // Jazzer brings in the JUnit5 API with a defined version.
+                dependencySet.add(dependencies.create("com.code-intelligence:jazzer-junit:$JAZZER_VERSION"))
+            }
+            if (configuration.name == testSetAccess.testRuntimeOnlyConfigurationName) {
+                // To run the tests, add 'junit-jupiter-engine' to 'runtimeOnly' scope of the selected source set.
+                // Add it without version - the version is automatically aligned with the JUnit 5 API.
+                dependencySet.add(dependencies.create("org.junit.jupiter:junit-jupiter-engine"))
+            }
+        }
+    }
+}
+
+private fun Project.reconfigureTestTasks(testTaskProvider: Provider<Test>, fuzzTestFilter: String) {
+    tasks.withType(Test::class.java).configureEach { testTask ->
+        // Only configure the test task that runs the fuzz tests
+        if (testTask == testTaskProvider.get()) {
+            // The task needs to use JUnit5 (useJUnitPlatform) and should only run @FuzzTest Jazzer tests
+            // (and no normal @Test tests).
+            testTask.useJUnitPlatform {
+                it.includeTags = setOf(JAZZER_JUNIT5_TEST_TAG)
+            }
+
+            testTask.ignoreFailures = true // Do not fail the build if a test fails
+            testTask.jvmArgs("-Djazzer.hooks=false") // disable Jazzer hooks as they are not needed for coverage
+
+            testTask.filter { filter ->
+                filter.includeTestsMatching(fuzzTestFilter) // Only include the fuzz test(s) specified by 'cifuzz'
+                filter.isFailOnNoMatchingTests = false // Do not fail the build if the test does not exist
+            }
+        }
+    }
+}
+
+private fun Project.registerCoverageReportingTask(testTask: Provider<Test>) {
+    plugins.apply("jacoco-report-aggregation") // This plugin was added in Gradle 7.4
+
+    val reporting = extensions.getByType(ReportingExtension::class.java)
+
+    // Register a new JacocoCoverageReport which will automatically add a task and configure it to pick up
+    // source code and classes from all dependencies, which is required in a multi-project setup.
+    reporting.reports.register("cifuzzReport", JacocoCoverageReport::class.java) { report ->
+        report.testType.convention("undefined") // Gradle 7.x requires this to not fail test classpath resolution
+        configureJacocoReportTask(report.reportTask, testTask)
+    }
+}
+
+private fun Project.registerCoverageReportingTaskLegacy(testSetAccess: TestSetAccess) {
+    plugins.apply("jacoco")
+
+    // Directly register a JacocoReport task, as JacocoCoverageReport (see above) is not available in Gradle
+    // versions older than 7.4.
+    val reportTask = tasks.register("cifuzzReport", JacocoReport::class.java) { cifuzzReport ->
+        val classesFolders = classesFolderView(testSetAccess)
+
+        // Add sources and classes (compiled code) from the CURRENT project
+        cifuzzReport.classDirectories.from(testSetAccess.mainClasses)
+        cifuzzReport.sourceDirectories.from(testSetAccess.mainSources)
+
+        // Add sources and classes (compiled code) from other projects the project depends on
+        cifuzzReport.classDirectories.from(classesFolders)
+        cifuzzReport.sourceDirectories.from(classesFolders.elements.map { classFolders ->
+            // Because the other projects do not always export their source code (before Gradle 7.4), we make the
+            // assumption that we can find it in a location relative to the classes.
+            classFolders.map {
+                val classFolder = it.asFile
+                val sourceSet = classFolder.name // usually 'main'
+                val jvmLanguage = classFolder.parentFile.name // usually 'java'
+                val projectRoot = classFolder.parentFile.parentFile.parentFile.parentFile
+                File(projectRoot, "$sourceSet/$jvmLanguage")
+            }
+        })
+    }
+
+    configureJacocoReportTask(reportTask, testSetAccess.testTask)
+}
+
+private fun Project.configureJacocoReportTask(reportTask: TaskProvider<JacocoReport>,
+                                              testTask: Provider<Test>
+) {
+    reportTask.configure { cifuzzReport ->
+        // Take the execution data from the fuzz test task.
+        // This adds a dependency to the task so that it will run before and produce the data.
+        cifuzzReport.executionData.setFrom(testTask.map { testTask ->
+            testTask.extensions.getByType(JacocoTaskExtension::class.java).destinationFile!!
+        })
+
+        cifuzzReport.reports { reports ->
+            // Configure which reports are produced, which can be influenced by 'cifuzz' through a Gradle property.
+            val format = gradleProperty("cifuzz.report.format") ?: "html"
+            reports.html.required.set(format != "jacocoxml")
+            reports.xml.required.set(true)
+
+            // Configure where the reports go, which can be influenced by 'cifuzz' through a Gradle property.
+            val output = gradleProperty("cifuzz.report.output")
+            if (output != null) {
+                reports.html.outputLocation.set(layout.projectDirectory.dir("$output/html"))
+                reports.xml.outputLocation.set(layout.projectDirectory.file("$output/jacoco.xml"))
+            }
+        }
+    }
+}
+
+private fun Project.classesFolderView(testSetAccess: TestSetAccess): FileCollection {
+    val testRuntimeClasspath = configurations.getByName(testSetAccess.testRuntimeClasspathConfigurationName)
+
+    // Get access to all 'classes' folders (compiled code) of dependencies through dependency management.
+    return testRuntimeClasspath.incoming.artifactView { view ->
+        view.componentFilter { id -> id is ProjectComponentIdentifier }
+        view.attributes.attribute(
+            LibraryElements.LIBRARY_ELEMENTS_ATTRIBUTE, objects.named(
+                LibraryElements::class.java, LibraryElements.CLASSES
+            )
+        )
+    }.files
+}
+
+private fun Project.gradleProperty(name: String): String? = if (isGradleVersionWithTestSuitesSupport) {
+    providers.gradleProperty(name).orNull
+} else {
+    // Fallback for older Gradle versions that either do not have 'Providers.gradleProperty' or require the
+    // now deprecated 'Provider.forUseAtConfigurationTime()'.
+    findProperty(name) as String?
+}

--- a/src/main/kotlin/com/code_intelligence/cifuzz/config/TaskConfigurations.kt
+++ b/src/main/kotlin/com/code_intelligence/cifuzz/config/TaskConfigurations.kt
@@ -1,6 +1,5 @@
 package com.code_intelligence.cifuzz.config
 
-import com.code_intelligence.cifuzz.CIFuzzExtension
 import com.code_intelligence.cifuzz.StandardJvmTestSetAccess
 import com.code_intelligence.cifuzz.TestSetAccess
 import com.code_intelligence.cifuzz.tasks.BuildDirectoryPrinter
@@ -13,8 +12,6 @@ import org.gradle.api.attributes.LibraryElements
 import org.gradle.api.file.FileCollection
 import org.gradle.api.provider.Provider
 import org.gradle.api.reporting.ReportingExtension
-import org.gradle.api.tasks.SourceSet
-import org.gradle.api.tasks.SourceSetContainer
 import org.gradle.api.tasks.TaskProvider
 import org.gradle.api.tasks.testing.Test
 import org.gradle.testing.jacoco.plugins.JacocoCoverageReport

--- a/src/main/kotlin/com/code_intelligence/cifuzz/tasks/PackagesPrinter.kt
+++ b/src/main/kotlin/com/code_intelligence/cifuzz/tasks/PackagesPrinter.kt
@@ -12,12 +12,12 @@ import org.gradle.api.tasks.TaskAction
 abstract class PackagesPrinter : DefaultTask() {
 
     @get:InputFiles
-    abstract val testRuntimeClasspath: ConfigurableFileCollection
+    abstract val runtimeClasspath: ConfigurableFileCollection
 
     @TaskAction
     fun print() {
         val packages = sortedSetOf<String>()
-        testRuntimeClasspath.filter { it.isDirectory }.forEach { classesFolder ->
+        runtimeClasspath.filter { it.isDirectory }.forEach { classesFolder ->
             classesFolder.walk().filter { it.extension == "class" }.forEach { classFile ->
                 packages.add(classFile.parentFile.relativeTo(classesFolder).toPath().joinToString("."))
             }

--- a/src/test/kotlin/com/code_intelligence/cifuzz/test/MultiProjectAndroidAppDebugVariantTest.kt
+++ b/src/test/kotlin/com/code_intelligence/cifuzz/test/MultiProjectAndroidAppDebugVariantTest.kt
@@ -1,0 +1,15 @@
+package com.code_intelligence.cifuzz.test
+
+import org.junit.jupiter.api.BeforeEach
+import java.io.File
+
+
+class MultiProjectAndroidAppDebugVariantTest : MultiProjectAndroidTest() {
+
+    override fun testedAndroidVariant() = "debug"
+
+    @BeforeEach
+    fun adjustSample() {
+        File(projectDir, "app/build.gradle.kts").appendText("""cifuzz.androidVariant.set("debug")""")
+    }
+}

--- a/src/test/kotlin/com/code_intelligence/cifuzz/test/MultiProjectAndroidAppDemoDebugVariantTest.kt
+++ b/src/test/kotlin/com/code_intelligence/cifuzz/test/MultiProjectAndroidAppDemoDebugVariantTest.kt
@@ -1,0 +1,33 @@
+package com.code_intelligence.cifuzz.test
+
+import org.junit.jupiter.api.BeforeEach
+import java.io.File
+
+
+class MultiProjectAndroidAppDemoDebugVariantTest : MultiProjectAndroidTest() {
+
+    override fun testedAndroidVariant() = "demoDebug"
+
+    @BeforeEach
+    fun adjustSample() {
+        File(projectDir, "app/build.gradle.kts").appendText("""
+            cifuzz.androidVariant.set("demoDebug")    
+            
+            android {
+                flavorDimensions += "version"
+                productFlavors {
+                    create("demo") {
+                        dimension = "version"
+                        applicationIdSuffix = ".demo"
+                        versionNameSuffix = "-demo"
+                    }
+                    create("full") {
+                        dimension = "version"
+                        applicationIdSuffix = ".full"
+                        versionNameSuffix = "-full"
+                    }
+                }
+            }
+        """.trimIndent())
+    }
+}

--- a/src/test/kotlin/com/code_intelligence/cifuzz/test/MultiProjectAndroidAppReleaseVariantTest.kt
+++ b/src/test/kotlin/com/code_intelligence/cifuzz/test/MultiProjectAndroidAppReleaseVariantTest.kt
@@ -1,0 +1,7 @@
+package com.code_intelligence.cifuzz.test
+
+
+class MultiProjectAndroidAppReleaseVariantTest : MultiProjectAndroidTest() {
+
+    override fun testedAndroidVariant() = "release"
+}

--- a/src/test/kotlin/com/code_intelligence/cifuzz/test/MultiProjectAndroidAppTest.kt
+++ b/src/test/kotlin/com/code_intelligence/cifuzz/test/MultiProjectAndroidAppTest.kt
@@ -1,0 +1,63 @@
+package com.code_intelligence.cifuzz.test
+
+import com.code_intelligence.cifuzz.test.fixture.CIFuzzPluginTest
+import org.gradle.testkit.runner.TaskOutcome
+import org.hamcrest.MatcherAssert.assertThat
+import org.hamcrest.Matchers.containsString
+import org.hamcrest.Matchers.not
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Tag
+import org.junit.jupiter.api.Test
+import java.io.File
+
+@Tag("android")
+class MultiProjectAndroidAppTest : CIFuzzPluginTest() {
+
+    override fun example() = "multi-project-android-app"
+
+    override fun cifuzzProjectDir() = File(projectDir, "app")
+
+    @Test
+    fun `cifuzzPrintBuildDir task can be called`() {
+        val result = runner("cifuzzPrintBuildDir", "-q").build()
+
+        assertEquals(TaskOutcome.SUCCESS, result.task(":app:cifuzzPrintBuildDir")?.outcome)
+        assertThat(result.output, containsString("cifuzz.buildDir="))
+        assertThat(result.output, containsString("/app/build\n"))
+    }
+
+    @Test
+    fun `cifuzzPrintTestClasspath task can be called`() {
+        val result = runner("cifuzzPrintTestClasspath", "-a").build()
+
+        assertEquals(TaskOutcome.SUCCESS, result.task(":app:cifuzzPrintTestClasspath")?.outcome)
+        assertThat(result.output, containsString("app/build/tmp/kotlin-classes/releaseUnitTest"))
+        assertThat(result.output, containsString("cifuzz.test.classpath="))
+    }
+
+    @Test
+    fun `cifuzzReport produces xml coverage report`() {
+        val reportFile = File(projectDir, "app/build/reports/jacoco/cifuzzReport/cifuzzReport.xml")
+
+        val result = runner("cifuzzReport", "-Pcifuzz.fuzztest=org.example.ExampleUnitTest.fuzzTest").build()
+
+        assertEquals(TaskOutcome.SUCCESS, result.task(":app:cifuzzReport")?.outcome)
+        assertTrue(reportFile.exists())
+        assertThat(reportFile.readText(), containsString("""<class name="org/example/MainFeature" sourcefilename="MainFeature.kt">"""))
+        assertThat(reportFile.readText(), containsString("""<class name="org/example/MainActivity" sourcefilename="MainActivity.kt">"""))
+    }
+
+    @Test
+    fun `cifuzzReport does not execute normal unit tests`() {
+        val reportFile = File(projectDir, "app/build/reports/tests/testReleaseUnitTest/classes/org.example.ExampleUnitTest.html")
+
+        // ModuleCTest contains a @FuzzTest and a @Test
+        val result = runner("cifuzzReport", "-Pcifuzz.fuzztest=org.example.ExampleUnitTest").build()
+
+        assertEquals(TaskOutcome.SUCCESS, result.task(":app:cifuzzReport")?.outcome)
+        assertTrue(reportFile.exists())
+        assertThat(reportFile.readText(), containsString(""">fuzzTest(byte[])[1]<"""))
+        assertThat(reportFile.readText(), not(containsString(""">unitTest()<""")))
+    }
+}

--- a/src/test/kotlin/com/code_intelligence/cifuzz/test/MultiProjectAndroidAppTest.kt
+++ b/src/test/kotlin/com/code_intelligence/cifuzz/test/MultiProjectAndroidAppTest.kt
@@ -29,7 +29,7 @@ class MultiProjectAndroidAppTest : CIFuzzPluginTest() {
 
     @Test
     fun `cifuzzPrintTestClasspath task can be called`() {
-        val result = runner("cifuzzPrintTestClasspath", "-a").build()
+        val result = runner("cifuzzPrintTestClasspath", "-q").build()
 
         assertEquals(TaskOutcome.SUCCESS, result.task(":app:cifuzzPrintTestClasspath")?.outcome)
         assertThat(result.output, containsString("app/build/tmp/kotlin-classes/releaseUnitTest"))
@@ -44,8 +44,11 @@ class MultiProjectAndroidAppTest : CIFuzzPluginTest() {
 
         assertEquals(TaskOutcome.SUCCESS, result.task(":app:cifuzzReport")?.outcome)
         assertTrue(reportFile.exists())
-        assertThat(reportFile.readText(), containsString("""<class name="org/example/MainFeature" sourcefilename="MainFeature.kt">"""))
-        assertThat(reportFile.readText(), containsString("""<class name="org/example/MainActivity" sourcefilename="MainActivity.kt">"""))
+        reportFile.readText().apply {
+            assertThat(this, containsString("""<class name="org/example/MainFeature" sourcefilename="MainFeature.kt">"""))
+            assertThat(this, containsString("""<class name="org/example/MainActivity" sourcefilename="MainActivity.kt">"""))
+            assertThat(this, containsString("""<class name="org/example/lib/Lib" sourcefilename="Lib.kt">"""))
+        }
     }
 
     @Test

--- a/src/test/kotlin/com/code_intelligence/cifuzz/test/MultiProjectAndroidTest.kt
+++ b/src/test/kotlin/com/code_intelligence/cifuzz/test/MultiProjectAndroidTest.kt
@@ -1,6 +1,7 @@
 package com.code_intelligence.cifuzz.test
 
 import com.code_intelligence.cifuzz.test.fixture.CIFuzzPluginTest
+import org.gradle.configurationcache.extensions.capitalized
 import org.gradle.testkit.runner.TaskOutcome
 import org.hamcrest.MatcherAssert.assertThat
 import org.hamcrest.Matchers.containsString
@@ -12,7 +13,9 @@ import org.junit.jupiter.api.Test
 import java.io.File
 
 @Tag("android")
-class MultiProjectAndroidAppTest : CIFuzzPluginTest() {
+abstract class MultiProjectAndroidTest : CIFuzzPluginTest() {
+
+    abstract fun testedAndroidVariant(): String
 
     override fun example() = "multi-project-android-app"
 
@@ -32,7 +35,7 @@ class MultiProjectAndroidAppTest : CIFuzzPluginTest() {
         val result = runner("cifuzzPrintTestClasspath", "-q").build()
 
         assertEquals(TaskOutcome.SUCCESS, result.task(":app:cifuzzPrintTestClasspath")?.outcome)
-        assertThat(result.output, containsString("app/build/tmp/kotlin-classes/releaseUnitTest"))
+        assertThat(result.output, containsString("app/build/tmp/kotlin-classes/${testedAndroidVariant()}UnitTest"))
         assertThat(result.output, containsString("cifuzz.test.classpath="))
     }
 
@@ -53,7 +56,7 @@ class MultiProjectAndroidAppTest : CIFuzzPluginTest() {
 
     @Test
     fun `cifuzzReport does not execute normal unit tests`() {
-        val reportFile = File(projectDir, "app/build/reports/tests/testReleaseUnitTest/classes/org.example.ExampleUnitTest.html")
+        val reportFile = File(projectDir, "app/build/reports/tests/test${testedAndroidVariant().capitalized()}UnitTest/classes/org.example.ExampleUnitTest.html")
 
         // ModuleCTest contains a @FuzzTest and a @Test
         val result = runner("cifuzzReport", "-Pcifuzz.fuzztest=org.example.ExampleUnitTest").build()

--- a/src/test/kotlin/com/code_intelligence/cifuzz/test/MultiProjectAndroidTest.kt
+++ b/src/test/kotlin/com/code_intelligence/cifuzz/test/MultiProjectAndroidTest.kt
@@ -1,7 +1,7 @@
 package com.code_intelligence.cifuzz.test
 
+import com.code_intelligence.cifuzz.android.capitalized
 import com.code_intelligence.cifuzz.test.fixture.CIFuzzPluginTest
-import org.gradle.configurationcache.extensions.capitalized
 import org.gradle.testkit.runner.TaskOutcome
 import org.hamcrest.MatcherAssert.assertThat
 import org.hamcrest.Matchers.containsString

--- a/src/test/kotlin/com/code_intelligence/cifuzz/test/android/MultiProjectAndroidAppDebugVariantTest.kt
+++ b/src/test/kotlin/com/code_intelligence/cifuzz/test/android/MultiProjectAndroidAppDebugVariantTest.kt
@@ -1,0 +1,15 @@
+package com.code_intelligence.cifuzz.test.android
+
+import org.junit.jupiter.api.BeforeEach
+import java.io.File
+
+
+class MultiProjectAndroidAppDebugVariantTest : MultiProjectAndroidTest() {
+
+    override fun testedAndroidVariant() = "debug"
+
+    @BeforeEach
+    fun adjustSample() {
+        File(projectDir, "app/build.gradle.kts").appendText("""cifuzz.androidVariant.set("debug")""")
+    }
+}

--- a/src/test/kotlin/com/code_intelligence/cifuzz/test/android/MultiProjectAndroidAppDemoDebugVariantTest.kt
+++ b/src/test/kotlin/com/code_intelligence/cifuzz/test/android/MultiProjectAndroidAppDemoDebugVariantTest.kt
@@ -1,0 +1,33 @@
+package com.code_intelligence.cifuzz.test.android
+
+import org.junit.jupiter.api.BeforeEach
+import java.io.File
+
+
+class MultiProjectAndroidAppDemoDebugVariantTest : MultiProjectAndroidTest() {
+
+    override fun testedAndroidVariant() = "demoDebug"
+
+    @BeforeEach
+    fun adjustSample() {
+        File(projectDir, "app/build.gradle.kts").appendText("""
+            cifuzz.androidVariant.set("demoDebug")    
+            
+            android {
+                flavorDimensions += "version"
+                productFlavors {
+                    create("demo") {
+                        dimension = "version"
+                        applicationIdSuffix = ".demo"
+                        versionNameSuffix = "-demo"
+                    }
+                    create("full") {
+                        dimension = "version"
+                        applicationIdSuffix = ".full"
+                        versionNameSuffix = "-full"
+                    }
+                }
+            }
+        """.trimIndent())
+    }
+}

--- a/src/test/kotlin/com/code_intelligence/cifuzz/test/android/MultiProjectAndroidAppReleaseVariantTest.kt
+++ b/src/test/kotlin/com/code_intelligence/cifuzz/test/android/MultiProjectAndroidAppReleaseVariantTest.kt
@@ -1,4 +1,4 @@
-package com.code_intelligence.cifuzz.test
+package com.code_intelligence.cifuzz.test.android
 
 
 class MultiProjectAndroidAppReleaseVariantTest : MultiProjectAndroidTest() {

--- a/src/test/kotlin/com/code_intelligence/cifuzz/test/android/MultiProjectAndroidLibDebugVariantTest.kt
+++ b/src/test/kotlin/com/code_intelligence/cifuzz/test/android/MultiProjectAndroidLibDebugVariantTest.kt
@@ -1,10 +1,10 @@
-package com.code_intelligence.cifuzz.test
+package com.code_intelligence.cifuzz.test.android
 
 import org.junit.jupiter.api.BeforeEach
 import java.io.File
 
 
-class MultiProjectAndroidAppDebugVariantTest : MultiProjectAndroidTest() {
+class MultiProjectAndroidLibDebugVariantTest : MultiProjectAndroidLibTest() {
 
     override fun testedAndroidVariant() = "debug"
 

--- a/src/test/kotlin/com/code_intelligence/cifuzz/test/android/MultiProjectAndroidLibDemoReleaseVariantTest.kt
+++ b/src/test/kotlin/com/code_intelligence/cifuzz/test/android/MultiProjectAndroidLibDemoReleaseVariantTest.kt
@@ -1,17 +1,17 @@
-package com.code_intelligence.cifuzz.test
+package com.code_intelligence.cifuzz.test.android
 
 import org.junit.jupiter.api.BeforeEach
 import java.io.File
 
 
-class MultiProjectAndroidAppDemoDebugVariantTest : MultiProjectAndroidTest() {
+class MultiProjectAndroidLibDemoReleaseVariantTest : MultiProjectAndroidTest() {
 
-    override fun testedAndroidVariant() = "demoDebug"
+    override fun testedAndroidVariant() = "demoRelease"
 
     @BeforeEach
     fun adjustSample() {
         File(projectDir, "app/build.gradle.kts").appendText("""
-            cifuzz.androidVariant.set("demoDebug")    
+            cifuzz.androidVariant.set("demoRelease")    
             
             android {
                 flavorDimensions += "version"

--- a/src/test/kotlin/com/code_intelligence/cifuzz/test/android/MultiProjectAndroidLibReleaseVariantTest.kt
+++ b/src/test/kotlin/com/code_intelligence/cifuzz/test/android/MultiProjectAndroidLibReleaseVariantTest.kt
@@ -1,0 +1,7 @@
+package com.code_intelligence.cifuzz.test.android
+
+
+class MultiProjectAndroidLibReleaseVariantTest : MultiProjectAndroidLibTest() {
+
+    override fun testedAndroidVariant() = "release"
+}

--- a/src/test/kotlin/com/code_intelligence/cifuzz/test/android/MultiProjectAndroidLibTest.kt
+++ b/src/test/kotlin/com/code_intelligence/cifuzz/test/android/MultiProjectAndroidLibTest.kt
@@ -1,0 +1,20 @@
+package com.code_intelligence.cifuzz.test.android
+
+import org.junit.jupiter.api.BeforeEach
+import java.io.File
+
+
+abstract class MultiProjectAndroidLibTest : MultiProjectAndroidTest() {
+
+    @BeforeEach
+    fun turnSampleIntoLibrary() {
+        File(projectDir, "app/build.gradle.kts").apply {
+            writeText(readText()
+                .replace("com.android.application", "com.android.library")
+                .replace("""applicationId = "org.example"""", "")
+                .replace("versionCode = 1", "")
+                .replace("""versionName = "1.0"""", "")
+            )
+        }
+    }
+}

--- a/src/test/kotlin/com/code_intelligence/cifuzz/test/android/MultiProjectAndroidTest.kt
+++ b/src/test/kotlin/com/code_intelligence/cifuzz/test/android/MultiProjectAndroidTest.kt
@@ -27,7 +27,7 @@ abstract class MultiProjectAndroidTest : CIFuzzPluginTest() {
 
         assertEquals(TaskOutcome.SUCCESS, result.task(":app:cifuzzPrintBuildDir")?.outcome)
         assertThat(result.output, containsString("cifuzz.buildDir="))
-        assertThat(result.output, containsString("/app/build\n"))
+        assertThat(result.output, containsString(File("app/build").path))
     }
 
     @Test
@@ -35,7 +35,7 @@ abstract class MultiProjectAndroidTest : CIFuzzPluginTest() {
         val result = runner("cifuzzPrintTestClasspath", "-q").build()
 
         assertEquals(TaskOutcome.SUCCESS, result.task(":app:cifuzzPrintTestClasspath")?.outcome)
-        assertThat(result.output, containsString("app/build/tmp/kotlin-classes/${testedAndroidVariant()}UnitTest"))
+        assertThat(result.output, containsString(File("app/build/tmp/kotlin-classes/${testedAndroidVariant()}UnitTest").path))
         assertThat(result.output, containsString("cifuzz.test.classpath="))
     }
 

--- a/src/test/kotlin/com/code_intelligence/cifuzz/test/android/MultiProjectAndroidTest.kt
+++ b/src/test/kotlin/com/code_intelligence/cifuzz/test/android/MultiProjectAndroidTest.kt
@@ -1,4 +1,4 @@
-package com.code_intelligence.cifuzz.test
+package com.code_intelligence.cifuzz.test.android
 
 import com.code_intelligence.cifuzz.android.capitalized
 import com.code_intelligence.cifuzz.test.fixture.CIFuzzPluginTest

--- a/src/test/kotlin/com/code_intelligence/cifuzz/test/fixture/CIFuzzPluginTest.kt
+++ b/src/test/kotlin/com/code_intelligence/cifuzz/test/fixture/CIFuzzPluginTest.kt
@@ -17,9 +17,13 @@ abstract class CIFuzzPluginTest {
 
     @BeforeEach
     fun setup() {
+        val androidVersion: String = System.getProperty("androidPluginVersionUnderTest") ?: "7.4.2"
+
         File("examples/${example()}").copyRecursively(projectDir)
         File(projectDir, "settings.gradle.kts").apply {
-            writeText(readText().replace("""includeBuild("../..")""", """repositories.maven("${File("build/pluginUnderTestRepo").absolutePath}")"""))
+            writeText(readText()
+                .replace("""includeBuild("../..")""", """repositories.maven("${File("build/pluginUnderTestRepo").absolutePath}")""")
+                .replace("7.4.2", androidVersion))
         }
         runner("clean")
     }

--- a/src/test/kotlin/com/code_intelligence/cifuzz/test/fixture/CIFuzzPluginTest.kt
+++ b/src/test/kotlin/com/code_intelligence/cifuzz/test/fixture/CIFuzzPluginTest.kt
@@ -18,8 +18,8 @@ abstract class CIFuzzPluginTest {
     @BeforeEach
     fun setup() {
         File("examples/${example()}").copyRecursively(projectDir)
-        File(projectDir, "settings.gradle.kts").let {
-            it.writeText(it.readText().replace("""includeBuild("../..")""", """repositories.maven("${File("build/pluginUnderTestRepo").absolutePath}")"""))
+        File(projectDir, "settings.gradle.kts").apply {
+            writeText(readText().replace("""includeBuild("../..")""", """repositories.maven("${File("build/pluginUnderTestRepo").absolutePath}")"""))
         }
         runner("clean")
     }

--- a/src/test/kotlin/com/code_intelligence/cifuzz/test/fixture/CIFuzzPluginTest.kt
+++ b/src/test/kotlin/com/code_intelligence/cifuzz/test/fixture/CIFuzzPluginTest.kt
@@ -19,7 +19,7 @@ abstract class CIFuzzPluginTest {
     fun setup() {
         File("examples/${example()}").copyRecursively(projectDir)
         File(projectDir, "settings.gradle.kts").let {
-            it.writeText(it.readText().replace("""pluginManagement { includeBuild("../..") }""", ""))
+            it.writeText(it.readText().replace("""includeBuild("../..")""", ""))
         }
         runner("clean")
     }

--- a/src/test/kotlin/com/code_intelligence/cifuzz/test/fixture/CIFuzzPluginTest.kt
+++ b/src/test/kotlin/com/code_intelligence/cifuzz/test/fixture/CIFuzzPluginTest.kt
@@ -19,7 +19,7 @@ abstract class CIFuzzPluginTest {
     fun setup() {
         File("examples/${example()}").copyRecursively(projectDir)
         File(projectDir, "settings.gradle.kts").let {
-            it.writeText(it.readText().replace("""includeBuild("../..")""", ""))
+            it.writeText(it.readText().replace("""includeBuild("../..")""", """repositories.maven("${File("build/pluginUnderTestRepo").absolutePath}")"""))
         }
         runner("clean")
     }
@@ -28,7 +28,6 @@ abstract class CIFuzzPluginTest {
         val gradleVersionUnderTest: String? = System.getProperty("gradleVersionUnderTest")
         return GradleRunner.create()
             .forwardOutput()
-            .withPluginClasspath()
             .withProjectDir(cifuzzProjectDir())
             .withArguments(args.toList() + listOf("-s"))
             .withDebug(ManagementFactory.getRuntimeMXBean().inputArguments.toString().contains("-agentlib:jdwp")).also {

--- a/src/test/kotlin/com/code_intelligence/cifuzz/test/fixture/CIFuzzPluginTest.kt
+++ b/src/test/kotlin/com/code_intelligence/cifuzz/test/fixture/CIFuzzPluginTest.kt
@@ -17,12 +17,13 @@ abstract class CIFuzzPluginTest {
 
     @BeforeEach
     fun setup() {
+        val localPluginRepo = File("build/pluginUnderTestRepo").absolutePath.replace(System.getProperty("file.separator"), "/")
         val androidVersion: String = System.getProperty("androidPluginVersionUnderTest") ?: "7.4.2"
 
         File("examples/${example()}").copyRecursively(projectDir)
         File(projectDir, "settings.gradle.kts").apply {
             writeText(readText()
-                .replace("""includeBuild("../..")""", """repositories.maven("${File("build/pluginUnderTestRepo").absolutePath}")""")
+                .replace("""includeBuild("../..")""","""repositories.maven("$localPluginRepo")""")
                 .replace("7.4.2", androidVersion))
         }
         runner("clean")


### PR DESCRIPTION
This PR allows this plugin to be used in combination with `com.android.application` or `com.android.library`. It supports fuzz tests that are _unit tests_ (located in _src/test_). The implementation is prepared to add support for Android device tests (located in _src/androidTest_) in a next step.

For usage details see updates in README:
- https://github.com/CodeIntelligenceTesting/cifuzz-gradle-plugin/tree/android-unit-tests#compatibility
- https://github.com/CodeIntelligenceTesting/cifuzz-gradle-plugin/tree/android-unit-tests#android-projects
