### PR TITLE
Android: Explicitly add 'testClassesDirs' of test task to test classpath

### DIFF
--- a/examples/multi-project-android-app-java/.gitignore
+++ b/examples/multi-project-android-app-java/.gitignore
@@ -1,0 +1,6 @@
+.gradle
+.idea
+build
+/gradle/wrapper
+/gradlew
+/gradlew.bat

--- a/examples/multi-project-android-app-java/app/build.gradle.kts
+++ b/examples/multi-project-android-app-java/app/build.gradle.kts
@@ -1,0 +1,30 @@
+plugins {
+    id("com.android.application")
+    id("com.code-intelligence.cifuzz") version "dev"
+}
+
+// cifuzz.androidVariant.set("debug")
+
+android {
+    namespace = "org.example"
+    compileSdk = 33
+
+    defaultConfig {
+        applicationId = "org.example"
+        minSdk = 26
+        targetSdk = 33
+        versionCode = 1
+        versionName = "1.0"
+
+        testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
+    }
+
+    compileOptions {
+        sourceCompatibility = JavaVersion.VERSION_1_8
+        targetCompatibility = JavaVersion.VERSION_1_8
+    }
+}
+
+dependencies {
+    implementation(project(":lib"))
+}

--- a/examples/multi-project-android-app-java/app/src/main/AndroidManifest.xml
+++ b/examples/multi-project-android-app-java/app/src/main/AndroidManifest.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools">
+
+    <application
+        android:label="App"
+        android:supportsRtl="true"
+        tools:targetApi="31">
+        <activity
+            android:name=".MainActivity"
+            android:exported="true"
+            android:label="App">
+            <intent-filter>
+                <action android:name="android.intent.action.MAIN" />
+
+                <category android:name="android.intent.category.LAUNCHER" />
+            </intent-filter>
+        </activity>
+    </application>
+
+</manifest>

--- a/examples/multi-project-android-app-java/app/src/main/java/org/example/MainActivity.java
+++ b/examples/multi-project-android-app-java/app/src/main/java/org/example/MainActivity.java
@@ -1,0 +1,11 @@
+package org.example;
+
+import android.app.Activity;
+import android.os.Bundle;
+
+public class MainActivity extends Activity {
+    public void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+    }
+}
+

--- a/examples/multi-project-android-app-java/app/src/main/java/org/example/MainFeature.java
+++ b/examples/multi-project-android-app-java/app/src/main/java/org/example/MainFeature.java
@@ -1,0 +1,7 @@
+package org.example;
+
+public class MainFeature  {
+    public boolean doSomething() {
+        return true;
+    }
+}

--- a/examples/multi-project-android-app-java/app/src/test/java/org/example/ExampleUnitTest.java
+++ b/examples/multi-project-android-app-java/app/src/test/java/org/example/ExampleUnitTest.java
@@ -1,0 +1,19 @@
+package org.example;
+
+import com.code_intelligence.jazzer.junit.FuzzTest;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class ExampleUnitTest {
+
+    @FuzzTest
+    void fuzzTest(byte[] data) {
+        assertTrue(new MainFeature().doSomething());
+    }
+
+    @Test
+    void unitTest() {
+        assertEquals(4, 2 + 2);
+    }
+}

--- a/examples/multi-project-android-app-java/build.gradle.kts
+++ b/examples/multi-project-android-app-java/build.gradle.kts
@@ -1,0 +1,3 @@
+plugins {
+    id("com.android.application") apply false
+}

--- a/examples/multi-project-android-app-java/gradle.properties
+++ b/examples/multi-project-android-app-java/gradle.properties
@@ -1,0 +1,2 @@
+android.useAndroidX=true
+org.gradle.jvmargs=-Xmx2g

--- a/examples/multi-project-android-app-java/lib/build.gradle.kts
+++ b/examples/multi-project-android-app-java/lib/build.gradle.kts
@@ -1,0 +1,20 @@
+plugins {
+    id("com.android.library")
+}
+
+android {
+    namespace = "org.example.lib"
+    compileSdk = 33
+
+    defaultConfig {
+        minSdk = 24
+        targetSdk = 33
+
+        testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
+    }
+
+    compileOptions {
+        sourceCompatibility = JavaVersion.VERSION_1_8
+        targetCompatibility = JavaVersion.VERSION_1_8
+    }
+}

--- a/examples/multi-project-android-app-java/lib/src/main/AndroidManifest.xml
+++ b/examples/multi-project-android-app-java/lib/src/main/AndroidManifest.xml
@@ -1,0 +1,3 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest>
+</manifest>

--- a/examples/multi-project-android-app-java/lib/src/main/java/org/example/lib/Lib.java
+++ b/examples/multi-project-android-app-java/lib/src/main/java/org/example/lib/Lib.java
@@ -1,0 +1,7 @@
+package org.example.lib;
+
+public class Lib {
+    boolean runLib() {
+        return true;
+    }
+}

--- a/examples/multi-project-android-app-java/settings.gradle.kts
+++ b/examples/multi-project-android-app-java/settings.gradle.kts
@@ -1,0 +1,19 @@
+pluginManagement {
+    includeBuild("../..")
+    repositories.google()
+    repositories.gradlePluginPortal()
+
+    plugins {
+        id("com.android.application") version "7.4.2"
+    }
+}
+
+dependencyResolutionManagement {
+    repositories {
+        google()
+        mavenCentral()
+    }
+}
+
+include("app")
+include("lib")

--- a/src/main/kotlin/com/code_intelligence/cifuzz/android/AndroidTestSetAccess.kt
+++ b/src/main/kotlin/com/code_intelligence/cifuzz/android/AndroidTestSetAccess.kt
@@ -9,6 +9,7 @@ import org.gradle.api.Task
 import org.gradle.api.attributes.Attribute
 import org.gradle.api.file.FileCollection
 import org.gradle.api.provider.Provider
+import org.gradle.api.tasks.testing.Test
 
 class AndroidTestSetAccess(
     private val project: Project,
@@ -24,9 +25,11 @@ class AndroidTestSetAccess(
     private fun testTaskPrefix() = if (testType == UnitTest::class.java) "test" else "connected"
 
     override val testRuntimeClasspath: FileCollection
-        get() = (testComponent().compileClasspath + testComponent().runtimeConfiguration.incoming.artifactView {
+        get() = (testComponent().runtimeConfiguration.incoming.artifactView {
             it.attributes.attribute(Attribute.of("artifactType", String::class.java), "android-classes-jar")
-        }.files)
+        }.files) + project.objects.fileCollection().from(testTask.map {
+            if (it is Test) { it.testClassesDirs } else project.objects.fileCollection()
+        })
 
     override val testImplementationConfigurationName: String
         get() = "${testConfigurationPrefix()}Implementation"

--- a/src/test/kotlin/com/code_intelligence/cifuzz/test/android/MultiProjectAndroidJavaAppReleaseTest.kt
+++ b/src/test/kotlin/com/code_intelligence/cifuzz/test/android/MultiProjectAndroidJavaAppReleaseTest.kt
@@ -1,0 +1,15 @@
+package com.code_intelligence.cifuzz.test.android
+
+import org.junit.jupiter.api.Tag
+
+@Tag("android")
+class MultiProjectAndroidJavaAppReleaseTest : MultiProjectAndroidTest() {
+
+    override fun testedAndroidVariant() =  "release"
+
+    override fun example() = "multi-project-android-app-java"
+
+    override fun languageFileExt() = "java"
+
+    override fun languageTestClassesPath() = "intermediates/javac"
+}

--- a/src/test/kotlin/com/code_intelligence/cifuzz/test/android/MultiProjectAndroidJavaLibDebugVariantTest.kt
+++ b/src/test/kotlin/com/code_intelligence/cifuzz/test/android/MultiProjectAndroidJavaLibDebugVariantTest.kt
@@ -1,0 +1,21 @@
+package com.code_intelligence.cifuzz.test.android
+
+import org.junit.jupiter.api.BeforeEach
+import java.io.File
+
+
+class MultiProjectAndroidJavaLibDebugVariantTest : MultiProjectAndroidLibTest() {
+
+    override fun testedAndroidVariant() = "debug"
+
+    override fun example() = "multi-project-android-app-java"
+
+    override fun languageFileExt() = "java"
+
+    override fun languageTestClassesPath() = "intermediates/javac"
+
+    @BeforeEach
+    fun adjustSample() {
+        File(projectDir, "app/build.gradle.kts").appendText("""cifuzz.androidVariant.set("debug")""")
+    }
+}

--- a/src/test/kotlin/com/code_intelligence/cifuzz/test/android/MultiProjectAndroidTest.kt
+++ b/src/test/kotlin/com/code_intelligence/cifuzz/test/android/MultiProjectAndroidTest.kt
@@ -21,6 +21,10 @@ abstract class MultiProjectAndroidTest : CIFuzzPluginTest() {
 
     override fun cifuzzProjectDir() = File(projectDir, "app")
 
+    open fun languageFileExt() = "kt"
+
+    open fun languageTestClassesPath() = "tmp/kotlin-classes"
+
     @Test
     fun `cifuzzPrintBuildDir task can be called`() {
         val result = runner("cifuzzPrintBuildDir", "-q").build()
@@ -35,7 +39,7 @@ abstract class MultiProjectAndroidTest : CIFuzzPluginTest() {
         val result = runner("cifuzzPrintTestClasspath", "-q").build()
 
         assertEquals(TaskOutcome.SUCCESS, result.task(":app:cifuzzPrintTestClasspath")?.outcome)
-        assertThat(result.output, containsString(File("app/build/tmp/kotlin-classes/${testedAndroidVariant()}UnitTest").path))
+        assertThat(result.output, containsString(File("app/build/${languageTestClassesPath()}/${testedAndroidVariant()}UnitTest").path))
         assertThat(result.output, containsString("cifuzz.test.classpath="))
     }
 
@@ -48,9 +52,9 @@ abstract class MultiProjectAndroidTest : CIFuzzPluginTest() {
         assertEquals(TaskOutcome.SUCCESS, result.task(":app:cifuzzReport")?.outcome)
         assertTrue(reportFile.exists())
         reportFile.readText().apply {
-            assertThat(this, containsString("""<class name="org/example/MainFeature" sourcefilename="MainFeature.kt">"""))
-            assertThat(this, containsString("""<class name="org/example/MainActivity" sourcefilename="MainActivity.kt">"""))
-            assertThat(this, containsString("""<class name="org/example/lib/Lib" sourcefilename="Lib.kt">"""))
+            assertThat(this, containsString("""<class name="org/example/MainFeature" sourcefilename="MainFeature.${languageFileExt()}">"""))
+            assertThat(this, containsString("""<class name="org/example/MainActivity" sourcefilename="MainActivity.${languageFileExt()}">"""))
+            assertThat(this, containsString("""<class name="org/example/lib/Lib" sourcefilename="Lib.${languageFileExt()}">"""))
         }
     }
 


### PR DESCRIPTION
Before we added the 'testComponent().compileClasspath' to avoid accessing the test task here. I was a bit surprised that that was enough, but it works for Android Kotlin projects, which seems to be some sort of side effect. Turns out that in pure Java projects that solution does not work.